### PR TITLE
Add signature image display to GI 3A form and statement

### DIFF
--- a/server/routes/export.ts
+++ b/server/routes/export.ts
@@ -1207,7 +1207,7 @@ async function generateStatementOfCaseHtml(
         </div>
 
         <div class="signature-area">
-          <div class="signature-line"></div>
+          ${signatureHtml}
 
           <div class="signature-label">
             (Signature and Name of the Authorised User)<br>


### PR DESCRIPTION
## Purpose

Based on user requirements, this change adds support for displaying uploaded signature images in both the GI 3A form and statement of case documents. Users requested that signature images uploaded by users should be included in these exported forms instead of just showing empty signature lines.

## Code changes

- **Form GI 3A**: Added CSS styling for signature images with proper sizing and borders, replaced static signature line with conditional rendering that shows either the uploaded signature image or a fallback signature line
- **Statement of Case**: Added similar signature image styling with larger dimensions appropriate for the statement format, implemented conditional signature rendering logic
- **Styling improvements**: Removed redundant border styling and added proper image constraints (max-width, max-height, object-fit) to ensure signatures display consistently across both document types

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 6`

🔗 [Edit in Builder.io](https://builder.io/app/projects/ddc9f038d4b9434295071fcf33d04d78/vortex-haven)

👀 [Preview Link](https://ddc9f038d4b9434295071fcf33d04d78-vortex-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ddc9f038d4b9434295071fcf33d04d78</projectId>-->
<!--<branchName>vortex-haven</branchName>-->