### PR TITLE
Add association stamps to card and NOC exports

### DIFF
--- a/server/routes/registrations.ts
+++ b/server/routes/registrations.ts
@@ -1961,31 +1961,35 @@ async function getProductAssociation(productName: string): Promise<string> {
 }
 
 // Helper function to get association stamp by association name
-async function getAssociationStamp(associationName: string): Promise<string | null> {
+async function getAssociationStamp(
+  associationName: string,
+): Promise<string | null> {
   console.log(`🔍 Looking up stamp for association: "${associationName}"`);
 
   try {
     // First try exact match
     let associationResult = await dbQuery(
       `SELECT stamp_image_path FROM associations WHERE name = ? LIMIT 1`,
-      [associationName]
+      [associationName],
     );
 
     // If no exact match, try fuzzy matching (remove hyphens, extra spaces, etc.)
     if (associationResult.length === 0) {
       console.log(`🔄 Trying fuzzy match for: ${associationName}`);
-      const normalizedInput = associationName.replace(/[-\s]+/g, ' ').trim();
+      const normalizedInput = associationName.replace(/[-\s]+/g, " ").trim();
 
       associationResult = await dbQuery(
         `SELECT stamp_image_path FROM associations WHERE REPLACE(REPLACE(name, '-', ' '), '  ', ' ') = ? LIMIT 1`,
-        [normalizedInput]
+        [normalizedInput],
       );
     }
 
     console.log(`📋 Association query result:`, associationResult);
 
     if (associationResult.length > 0 && associationResult[0].stamp_image_path) {
-      console.log(`✅ Found association stamp: ${associationResult[0].stamp_image_path}`);
+      console.log(
+        `✅ Found association stamp: ${associationResult[0].stamp_image_path}`,
+      );
       return associationResult[0].stamp_image_path;
     }
 


### PR DESCRIPTION
## Purpose
Users identified that association type information was missing from card and NOC exports. They needed the proper association stamps to appear in these exported documents instead of user signatures or empty signature lines.

## Code changes
- **Added new products**: Added "Bodo Gongar Dunjia" and "Bodo Ondla" to the product association mapping
- **Fixed association name**: Corrected "Bodo Keradapini" association name (removed hyphen)
- **New helper function**: Created `getAssociationStamp()` function to fetch association stamp images from database with fuzzy matching support
- **Updated NOC export**: Modified `generateProductNOCHtml()` to use association stamps instead of empty signature lines
- **Updated Card export**: Modified `generateProductCardHtml()` to use association stamps instead of user signatures
- **Enhanced logging**: Added comprehensive console logging for debugging stamp lookup process

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 8`

🔗 [Edit in Builder.io](https://builder.io/app/projects/ddc9f038d4b9434295071fcf33d04d78/orbit-sanctuary)

👀 [Preview Link](https://ddc9f038d4b9434295071fcf33d04d78-orbit-sanctuary.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ddc9f038d4b9434295071fcf33d04d78</projectId>-->
<!--<branchName>orbit-sanctuary</branchName>-->