### PR TITLE
Fix turnover unit storage bug in registration forms

### DIFF
--- a/server/routes/registrations.ts
+++ b/server/routes/registrations.ts
@@ -138,6 +138,12 @@ export async function createRegistration(req: AuthRequest, res: Response) {
       console.error("Error parsing existingProductDetails:", error);
     }
 
+    // Resolve turnover unit without forcing a default; if none provided, use the first production detail's unit
+    const resolvedTurnoverUnit: string | null =
+      turnoverUnit ?? (Array.isArray(productionDetails) && productionDetails.length > 0
+        ? (productionDetails[0]?.turnoverUnit ?? null)
+        : null);
+
     // Validate required fields (PAN Card and Proof of Production are now optional)
     if (
       !name ||
@@ -247,7 +253,7 @@ export async function createRegistration(req: AuthRequest, res: Response) {
         areaOfProduction || null,
         annualProduction || null,
         annualTurnover,
-        turnoverUnit || "lakh",
+        resolvedTurnoverUnit,
         yearsOfProduction || null,
       ],
     );
@@ -1022,6 +1028,12 @@ export async function createAdditionalRegistration(
       console.error("Error parsing productionDetails:", error);
     }
 
+    // Resolve turnover unit without forcing a default for additional registrations
+    const resolvedTurnoverUnit: string | null =
+      turnoverUnit ?? (Array.isArray(productionDetails) && productionDetails.length > 0
+        ? (productionDetails[0]?.turnoverUnit ?? null)
+        : null);
+
     // Get the base registration to reuse file paths and personal data
     const baseRegistration = await dbQuery(
       "SELECT * FROM user_registrations WHERE id = ? AND user_id = ?",
@@ -1061,7 +1073,7 @@ export async function createAdditionalRegistration(
         areaOfProduction || null,
         annualProduction || null,
         annualTurnover,
-        turnoverUnit || "lakh",
+        resolvedTurnoverUnit,
         yearsOfProduction || null,
         // Reuse existing file paths
         baseReg.aadhar_card_path,

--- a/server/routes/registrations.ts
+++ b/server/routes/registrations.ts
@@ -144,7 +144,10 @@ export async function createRegistration(req: AuthRequest, res: Response) {
       if (Array.isArray(productionDetails) && productionDetails.length > 0) {
         return productionDetails[0]?.turnoverUnit ?? null;
       }
-      if (existingProductDetails && typeof existingProductDetails === "object") {
+      if (
+        existingProductDetails &&
+        typeof existingProductDetails === "object"
+      ) {
         const first = Object.values(existingProductDetails)[0] as any;
         return (first as any)?.turnoverUnit ?? null;
       }
@@ -1037,7 +1040,8 @@ export async function createAdditionalRegistration(
 
     // Resolve turnover unit without forcing a default for additional registrations
     const resolvedTurnoverUnit: string | null =
-      turnoverUnit ?? (Array.isArray(productionDetails) && productionDetails.length > 0
+      turnoverUnit ??
+      (Array.isArray(productionDetails) && productionDetails.length > 0
         ? (productionDetails[0]?.turnoverUnit ?? null)
         : null);
 


### PR DESCRIPTION
## Purpose
User reported a critical data integrity issue where the registration form was incorrectly storing "lakhs" in the database even when "thousand" was selected in the turnover unit dropdown. This bug was affecting the accuracy of financial data being captured during the registration process.

## Code changes
- **Removed hardcoded default**: Eliminated the fallback to "lakh" as default turnover unit that was overriding user selections
- **Added intelligent unit resolution**: Implemented `resolvedTurnoverUnit` logic that prioritizes explicit user input, then falls back to production details, then existing product details
- **Applied fix to both registration flows**: Updated both `createRegistration` and `createAdditionalRegistration` functions to use the new resolution logic
- **Preserved data integrity**: Changed from forcing a default value to allowing `null` when no valid turnover unit is available, preventing incorrect data storage

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 14`

🔗 [Edit in Builder.io](https://builder.io/app/projects/1b89e588fd464aaa836404f75cf8e518/pixel-verse)

👀 [Preview Link](https://1b89e588fd464aaa836404f75cf8e518-pixel-verse.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>1b89e588fd464aaa836404f75cf8e518</projectId>-->
<!--<branchName>pixel-verse</branchName>-->