### PR TITLE
Add existing products column to export functions

### DIFF
--- a/client/pages/AdminDashboard.tsx
+++ b/client/pages/AdminDashboard.tsx
@@ -342,13 +342,17 @@ export default function AdminDashboard() {
       } else {
         let errorMessage = "Export failed";
         try {
-          const errorData = await response.json();
-          errorMessage =
-            errorData.error ||
-            `HTTP ${response.status}: ${response.statusText}`;
+          const contentType = response.headers.get("Content-Type") || "";
+          if (contentType.includes("application/json")) {
+            const errorData = await response.json();
+            errorMessage = errorData.error || `HTTP ${response.status}`;
+          } else {
+            const text = await response.text();
+            errorMessage = text || `HTTP ${response.status}`;
+          }
         } catch (parseError) {
-          console.error("Failed to parse error response:", parseError);
-          errorMessage = `HTTP ${response.status}: ${response.statusText}`;
+          console.error("Failed to read error response", parseError);
+          errorMessage = `HTTP ${response.status}`;
         }
         throw new Error(errorMessage);
       }
@@ -414,13 +418,17 @@ export default function AdminDashboard() {
       } else {
         let errorMessage = "Export failed";
         try {
-          const errorData = await response.json();
-          errorMessage =
-            errorData.error ||
-            `HTTP ${response.status}: ${response.statusText}`;
+          const contentType = response.headers.get("Content-Type") || "";
+          if (contentType.includes("application/json")) {
+            const errorData = await response.json();
+            errorMessage = errorData.error || `HTTP ${response.status}`;
+          } else {
+            const text = await response.text();
+            errorMessage = text || `HTTP ${response.status}`;
+          }
         } catch (parseError) {
-          console.error("Failed to parse error response:", parseError);
-          errorMessage = `HTTP ${response.status}: ${response.statusText}`;
+          console.error("Failed to read error response", parseError);
+          errorMessage = `HTTP ${response.status}`;
         }
         throw new Error(errorMessage);
       }
@@ -488,13 +496,17 @@ export default function AdminDashboard() {
       } else {
         let errorMessage = "Export failed";
         try {
-          const errorData = await response.json();
-          errorMessage =
-            errorData.error ||
-            `HTTP ${response.status}: ${response.statusText}`;
+          const contentType = response.headers.get("Content-Type") || "";
+          if (contentType.includes("application/json")) {
+            const errorData = await response.json();
+            errorMessage = errorData.error || `HTTP ${response.status}`;
+          } else {
+            const text = await response.text();
+            errorMessage = text || `HTTP ${response.status}`;
+          }
         } catch (parseError) {
-          console.error("Failed to parse error response:", parseError);
-          errorMessage = `HTTP ${response.status}: ${response.statusText}`;
+          console.error("Failed to read error response", parseError);
+          errorMessage = `HTTP ${response.status}`;
         }
         throw new Error(errorMessage);
       }

--- a/client/pages/AdminDashboard.tsx
+++ b/client/pages/AdminDashboard.tsx
@@ -130,7 +130,9 @@ export default function AdminDashboard() {
       const initializeData = async () => {
         const isConnected = await testConnectivity();
         if (!isConnected) {
-          console.warn("Connectivity check failed, proceeding to fetch data anyway");
+          console.warn(
+            "Connectivity check failed, proceeding to fetch data anyway",
+          );
         }
 
         await Promise.all([
@@ -342,11 +344,18 @@ export default function AdminDashboard() {
         let errorMessage = `HTTP ${response.status}`;
         try {
           if (!response.bodyUsed) {
-            const errResp = typeof response.clone === "function" ? response.clone() : response;
+            const errResp =
+              typeof response.clone === "function"
+                ? response.clone()
+                : response;
             const contentType = errResp.headers.get("Content-Type") || "";
             if (contentType.includes("application/json")) {
               const errorData = await errResp.json();
-              if (errorData && typeof errorData === "object" && "error" in errorData) {
+              if (
+                errorData &&
+                typeof errorData === "object" &&
+                "error" in errorData
+              ) {
                 errorMessage = (errorData as any).error || errorMessage;
               }
             } else {
@@ -422,11 +431,18 @@ export default function AdminDashboard() {
         let errorMessage = `HTTP ${response.status}`;
         try {
           if (!response.bodyUsed) {
-            const errResp = typeof response.clone === "function" ? response.clone() : response;
+            const errResp =
+              typeof response.clone === "function"
+                ? response.clone()
+                : response;
             const contentType = errResp.headers.get("Content-Type") || "";
             if (contentType.includes("application/json")) {
               const errorData = await errResp.json();
-              if (errorData && typeof errorData === "object" && "error" in errorData) {
+              if (
+                errorData &&
+                typeof errorData === "object" &&
+                "error" in errorData
+              ) {
                 errorMessage = (errorData as any).error || errorMessage;
               }
             } else {
@@ -504,11 +520,18 @@ export default function AdminDashboard() {
         let errorMessage = `HTTP ${response.status}`;
         try {
           if (!response.bodyUsed) {
-            const errResp = typeof response.clone === "function" ? response.clone() : response;
+            const errResp =
+              typeof response.clone === "function"
+                ? response.clone()
+                : response;
             const contentType = errResp.headers.get("Content-Type") || "";
             if (contentType.includes("application/json")) {
               const errorData = await errResp.json();
-              if (errorData && typeof errorData === "object" && "error" in errorData) {
+              if (
+                errorData &&
+                typeof errorData === "object" &&
+                "error" in errorData
+              ) {
                 errorMessage = (errorData as any).error || errorMessage;
               }
             } else {

--- a/client/pages/AdminDashboard.tsx
+++ b/client/pages/AdminDashboard.tsx
@@ -339,20 +339,23 @@ export default function AdminDashboard() {
         window.URL.revokeObjectURL(url);
         document.body.removeChild(a);
       } else {
-        let errorMessage = "Export failed";
+        let errorMessage = `HTTP ${response.status}`;
         try {
-          const errResp = response.clone();
-          const contentType = errResp.headers.get("Content-Type") || "";
-          if (contentType.includes("application/json")) {
-            const errorData = await errResp.json();
-            errorMessage = errorData.error || `HTTP ${response.status}`;
-          } else {
-            const text = await errResp.text();
-            errorMessage = text || `HTTP ${response.status}`;
+          if (!response.bodyUsed) {
+            const errResp = typeof response.clone === "function" ? response.clone() : response;
+            const contentType = errResp.headers.get("Content-Type") || "";
+            if (contentType.includes("application/json")) {
+              const errorData = await errResp.json();
+              if (errorData && typeof errorData === "object" && "error" in errorData) {
+                errorMessage = (errorData as any).error || errorMessage;
+              }
+            } else {
+              const text = await errResp.text();
+              if (text) errorMessage = text;
+            }
           }
         } catch (parseError) {
           console.error("Failed to read error response", parseError);
-          errorMessage = `HTTP ${response.status}`;
         }
         throw new Error(errorMessage);
       }
@@ -416,20 +419,23 @@ export default function AdminDashboard() {
         window.URL.revokeObjectURL(url);
         document.body.removeChild(a);
       } else {
-        let errorMessage = "Export failed";
+        let errorMessage = `HTTP ${response.status}`;
         try {
-          const errResp = response.clone();
-          const contentType = errResp.headers.get("Content-Type") || "";
-          if (contentType.includes("application/json")) {
-            const errorData = await errResp.json();
-            errorMessage = errorData.error || `HTTP ${response.status}`;
-          } else {
-            const text = await errResp.text();
-            errorMessage = text || `HTTP ${response.status}`;
+          if (!response.bodyUsed) {
+            const errResp = typeof response.clone === "function" ? response.clone() : response;
+            const contentType = errResp.headers.get("Content-Type") || "";
+            if (contentType.includes("application/json")) {
+              const errorData = await errResp.json();
+              if (errorData && typeof errorData === "object" && "error" in errorData) {
+                errorMessage = (errorData as any).error || errorMessage;
+              }
+            } else {
+              const text = await errResp.text();
+              if (text) errorMessage = text;
+            }
           }
         } catch (parseError) {
           console.error("Failed to read error response", parseError);
-          errorMessage = `HTTP ${response.status}`;
         }
         throw new Error(errorMessage);
       }
@@ -495,20 +501,23 @@ export default function AdminDashboard() {
         window.URL.revokeObjectURL(url);
         document.body.removeChild(a);
       } else {
-        let errorMessage = "Export failed";
+        let errorMessage = `HTTP ${response.status}`;
         try {
-          const errResp = response.clone();
-          const contentType = errResp.headers.get("Content-Type") || "";
-          if (contentType.includes("application/json")) {
-            const errorData = await errResp.json();
-            errorMessage = errorData.error || `HTTP ${response.status}`;
-          } else {
-            const text = await errResp.text();
-            errorMessage = text || `HTTP ${response.status}`;
+          if (!response.bodyUsed) {
+            const errResp = typeof response.clone === "function" ? response.clone() : response;
+            const contentType = errResp.headers.get("Content-Type") || "";
+            if (contentType.includes("application/json")) {
+              const errorData = await errResp.json();
+              if (errorData && typeof errorData === "object" && "error" in errorData) {
+                errorMessage = (errorData as any).error || errorMessage;
+              }
+            } else {
+              const text = await errResp.text();
+              if (text) errorMessage = text;
+            }
           }
         } catch (parseError) {
           console.error("Failed to read error response", parseError);
-          errorMessage = `HTTP ${response.status}`;
         }
         throw new Error(errorMessage);
       }

--- a/client/pages/AdminDashboard.tsx
+++ b/client/pages/AdminDashboard.tsx
@@ -130,8 +130,7 @@ export default function AdminDashboard() {
       const initializeData = async () => {
         const isConnected = await testConnectivity();
         if (!isConnected) {
-          console.warn("Skipping data fetch due to connectivity issues");
-          return;
+          console.warn("Connectivity check failed, proceeding to fetch data anyway");
         }
 
         await Promise.all([
@@ -342,12 +341,13 @@ export default function AdminDashboard() {
       } else {
         let errorMessage = "Export failed";
         try {
-          const contentType = response.headers.get("Content-Type") || "";
+          const errResp = response.clone();
+          const contentType = errResp.headers.get("Content-Type") || "";
           if (contentType.includes("application/json")) {
-            const errorData = await response.json();
+            const errorData = await errResp.json();
             errorMessage = errorData.error || `HTTP ${response.status}`;
           } else {
-            const text = await response.text();
+            const text = await errResp.text();
             errorMessage = text || `HTTP ${response.status}`;
           }
         } catch (parseError) {
@@ -418,12 +418,13 @@ export default function AdminDashboard() {
       } else {
         let errorMessage = "Export failed";
         try {
-          const contentType = response.headers.get("Content-Type") || "";
+          const errResp = response.clone();
+          const contentType = errResp.headers.get("Content-Type") || "";
           if (contentType.includes("application/json")) {
-            const errorData = await response.json();
+            const errorData = await errResp.json();
             errorMessage = errorData.error || `HTTP ${response.status}`;
           } else {
-            const text = await response.text();
+            const text = await errResp.text();
             errorMessage = text || `HTTP ${response.status}`;
           }
         } catch (parseError) {
@@ -496,12 +497,13 @@ export default function AdminDashboard() {
       } else {
         let errorMessage = "Export failed";
         try {
-          const contentType = response.headers.get("Content-Type") || "";
+          const errResp = response.clone();
+          const contentType = errResp.headers.get("Content-Type") || "";
           if (contentType.includes("application/json")) {
-            const errorData = await response.json();
+            const errorData = await errResp.json();
             errorMessage = errorData.error || `HTTP ${response.status}`;
           } else {
-            const text = await response.text();
+            const text = await errResp.text();
             errorMessage = text || `HTTP ${response.status}`;
           }
         } catch (parseError) {

--- a/server/routes/export.ts
+++ b/server/routes/export.ts
@@ -51,7 +51,8 @@ export async function exportUsersWithDateRange(req: Request, res: Response) {
         ur.photo_path,
         ur.signature_path,
         GROUP_CONCAT(DISTINCT pc.name) as category_names,
-        GROUP_CONCAT(DISTINCT p.name) as product_names,
+        GROUP_CONCAT(DISTINCT p.name) as selected_products,
+        GROUP_CONCAT(DISTINCT ep.name) as existing_products,
         u.username,
         u.email as user_email
       FROM user_registrations ur
@@ -60,6 +61,8 @@ export async function exportUsersWithDateRange(req: Request, res: Response) {
       LEFT JOIN product_categories pc ON urc.category_id = pc.id
       LEFT JOIN user_selected_products usp ON ur.id = usp.registration_id
       LEFT JOIN products p ON usp.product_id = p.id
+      LEFT JOIN user_existing_products uep ON ur.id = uep.registration_id
+      LEFT JOIN products ep ON uep.product_id = ep.id
       WHERE DATE(ur.created_at) BETWEEN ? AND ?
       GROUP BY ur.id
       ORDER BY ur.created_at DESC
@@ -86,7 +89,8 @@ export async function exportUsersWithDateRange(req: Request, res: Response) {
       "Voter ID",
       "PAN Number",
       "Categories",
-      "Products",
+      "Selected Products",
+      "Existing Products",
       "Username",
       "User Email",
       "Registration Date",
@@ -104,7 +108,8 @@ export async function exportUsersWithDateRange(req: Request, res: Response) {
       reg.voter_id || "",
       reg.pan_number || "",
       `"${reg.category_names || ""}"`,
-      `"${reg.product_names || ""}"`,
+      `"${reg.selected_products || ""}"`,
+      `"${reg.existing_products || ""}"`,
       reg.username || "",
       reg.user_email || "",
       new Date(reg.created_at).toLocaleDateString("en-GB"),
@@ -164,12 +169,15 @@ export async function exportRegistrationsByUser(req: Request, res: Response) {
         ur.photo_path,
         ur.signature_path,
         GROUP_CONCAT(DISTINCT pc.name) as category_names,
-        GROUP_CONCAT(DISTINCT p.name) as product_names
+        GROUP_CONCAT(DISTINCT p.name) as selected_products,
+        GROUP_CONCAT(DISTINCT ep.name) as existing_products
       FROM user_registrations ur
       LEFT JOIN user_registration_categories urc ON ur.id = urc.registration_id
       LEFT JOIN product_categories pc ON urc.category_id = pc.id
       LEFT JOIN user_selected_products usp ON ur.id = usp.registration_id
       LEFT JOIN products p ON usp.product_id = p.id
+      LEFT JOIN user_existing_products uep ON ur.id = uep.registration_id
+      LEFT JOIN products ep ON uep.product_id = ep.id
       WHERE ur.user_id = ?
       GROUP BY ur.id
       ORDER BY ur.created_at DESC
@@ -196,7 +204,8 @@ export async function exportRegistrationsByUser(req: Request, res: Response) {
       "Voter ID",
       "PAN Number",
       "Categories",
-      "Products",
+      "Selected Products",
+      "Existing Products",
       "Registration Date",
     ];
 
@@ -212,7 +221,8 @@ export async function exportRegistrationsByUser(req: Request, res: Response) {
       reg.voter_id || "",
       reg.pan_number || "",
       `"${reg.category_names || ""}"`,
-      `"${reg.product_names || ""}"`,
+      `"${reg.selected_products || ""}"`,
+      `"${reg.existing_products || ""}"`,
       new Date(reg.created_at).toLocaleDateString("en-GB"),
     ]);
 


### PR DESCRIPTION
## Purpose

Based on user feedback, this change addresses the need to distinguish between selected products and existing products in export functionality. Users requested clarification on what "products" meant in exports and wanted to see both selected products and existing products as separate columns in the exported data.

## Code changes

### Backend (server/routes/export.ts)
- Added JOIN with `user_existing_products` and `products` tables to fetch existing products
- Split the products column into two separate columns: "Selected Products" and "Existing Products"
- Updated SQL queries for both `exportUsersWithDateRange` and `exportRegistrationsByUser` functions
- Modified CSV headers to reflect the new column structure

### Frontend (client/pages/AdminDashboard.tsx)
- Improved error handling for export functions with better response parsing
- Added support for different content types (JSON and text) in error responses
- Enhanced connectivity check to proceed with data fetch even if connectivity test fails
- Added proper response cloning to avoid "body already used" errorsTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 19`

🔗 [Edit in Builder.io](https://builder.io/app/projects/62d87c2082fb4fdc9646f6841aea4fc5/cosmos-nest)

👀 [Preview Link](https://62d87c2082fb4fdc9646f6841aea4fc5-cosmos-nest.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>62d87c2082fb4fdc9646f6841aea4fc5</projectId>-->
<!--<branchName>cosmos-nest</branchName>-->