### PR TITLE
Change product export format from comma to newline separated

### DIFF
--- a/server/routes/export.ts
+++ b/server/routes/export.ts
@@ -56,8 +56,8 @@ export async function exportUsersWithDateRange(req: Request, res: Response) {
         ur.photo_path,
         ur.signature_path,
         GROUP_CONCAT(DISTINCT pc.name) as category_names,
-        GROUP_CONCAT(DISTINCT p.name) as selected_products,
-        GROUP_CONCAT(DISTINCT ep.name) as existing_products,
+        GROUP_CONCAT(DISTINCT p.name SEPARATOR '\n') as selected_products,
+        GROUP_CONCAT(DISTINCT ep.name SEPARATOR '\n') as existing_products,
         u.username,
         u.email as user_email
       FROM user_registrations ur
@@ -233,7 +233,7 @@ export async function exportRegistrationsByUser(req: Request, res: Response) {
         ur.photo_path,
         ur.signature_path,
         GROUP_CONCAT(DISTINCT pc.name) as category_names,
-        GROUP_CONCAT(DISTINCT p.name) as selected_products,
+        GROUP_CONCAT(DISTINCT p.name SEPARATOR '\n') as selected_products,
         GROUP_CONCAT(DISTINCT ep.name) as existing_products
       FROM user_registrations ur
       LEFT JOIN user_registration_categories urc ON ur.id = urc.registration_id
@@ -406,7 +406,7 @@ export async function exportUsersByProducts(req: Request, res: Response) {
         u.username,
         u.email as user_email,
         GROUP_CONCAT(DISTINCT pc.name) as category_names,
-        GROUP_CONCAT(DISTINCT p.name) as selected_products,
+        GROUP_CONCAT(DISTINCT p.name SEPARATOR '\n') as selected_products,
         GROUP_CONCAT(DISTINCT ep.name) as existing_products
       FROM user_registrations ur
       LEFT JOIN users u ON ur.user_id = u.id


### PR DESCRIPTION
## Purpose
The user requested to improve the admin dashboard export functionality. Instead of displaying multiple products in a comma-separated format on a single line, they wanted each product to appear on a separate line for better readability and organization in the exported data.

## Code changes
- Modified SQL queries in `server/routes/export.ts` to use newline separator (`\n`) instead of default comma separator for product concatenation
- Updated `GROUP_CONCAT` statements for `selected_products` and `existing_products` fields across three export functions:
  - `exportUsersWithDateRange`
  - `exportRegistrationsByUser` 
  - `exportUsersByProducts`
- Added `SEPARATOR '\n'` parameter to `GROUP_CONCAT(DISTINCT p.name)` and `GROUP_CONCAT(DISTINCT ep.name)` statementsTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 22`

🔗 [Edit in Builder.io](https://builder.io/app/projects/62d87c2082fb4fdc9646f6841aea4fc5/nova-den)

👀 [Preview Link](https://62d87c2082fb4fdc9646f6841aea4fc5-nova-den.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>62d87c2082fb4fdc9646f6841aea4fc5</projectId>-->
<!--<branchName>nova-den</branchName>-->