### PR TITLE
Add product IDs to NOC certificates and exports

### DIFF
--- a/server/routes/export.ts
+++ b/server/routes/export.ts
@@ -1154,7 +1154,9 @@ async function generateNOCHtml(
 
   // Generate application number based on registration ID and date
   const appNumber = `GI-BODO-${new Date().getFullYear()}-${registration.id.toString().padStart(4, "0")}`;
-  const displayAppNumber = primaryProductId ? `${appNumber} - Product ID: ${primaryProductId}` : appNumber;
+  const displayAppNumber = primaryProductId
+    ? `${appNumber} - Product ID: ${primaryProductId}`
+    : appNumber;
 
   // Organization details - Generic for bulk exports covering multiple associations
   const organizationName = "Bodo Traditional Producers Consortium";

--- a/server/routes/registrations.ts
+++ b/server/routes/registrations.ts
@@ -1785,7 +1785,11 @@ export async function exportProductNOC(req: Request, res: Response) {
       productData.length > 0 ? productData[0].description : null;
 
     // Generate HTML for the specific product
-    const nocHtml = await generateProductNOCHtml(registration, productName, productId);
+    const nocHtml = await generateProductNOCHtml(
+      registration,
+      productName,
+      productId,
+    );
 
     // Create complete HTML document
     const fullHtml = `
@@ -2220,9 +2224,7 @@ async function getAssociationStamp(
 }
 
 // Helper to get both stamp and registration short form (registration_number) from associations
-async function getAssociationDetails(
-  associationName: string,
-): Promise<{
+async function getAssociationDetails(associationName: string): Promise<{
   stamp_image_path: string | null;
   registration_number: string | null;
 }> {
@@ -2393,7 +2395,9 @@ async function generateProductNOCHtml(
 ): Promise<string> {
   const certificateDate = new Date().toLocaleDateString("en-GB");
   const appNumber = `GI-BODO-${new Date().getFullYear()}-${registration.id.toString().padStart(4, "0")}`;
-  const displayAppNumber = productId ? `${appNumber} - Product ID: ${productId}` : appNumber;
+  const displayAppNumber = productId
+    ? `${appNumber} - Product ID: ${productId}`
+    : appNumber;
 
   // Use association from registration data if available, otherwise use static mapping
   let organizationName = registration.product_association;


### PR DESCRIPTION
## Purpose

The user requested to add product IDs from the product table to NOC (No Objection Certificate) documents. This enhancement provides better traceability by including the database product ID alongside the existing GI Application Number in certificate text.

## Code changes

- **Database queries**: Added `GROUP_CONCAT(DISTINCT p.id) as product_ids` to all export functions (exportFormGI3A, exportNOC, exportStatementOfCase, exportProducerCards)
- **Interface update**: Added optional `product_ids` field to `RegistrationData` interface
- **Certificate generation**: Modified NOC HTML generation to include product ID in application number display format
- **Display format**: Updated certificate text to show `GI-BODO-YYYY-XXXX - Product ID: [ID]` when product ID is available
- **Function signatures**: Updated `generateProductNOCHtml` to accept optional `productId` parameter

The changes ensure that NOC certificates now display both the GI Application Number and the corresponding product ID for better identification and tracking.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 32`

🔗 [Edit in Builder.io](https://builder.io/app/projects/62d87c2082fb4fdc9646f6841aea4fc5/vibe-world)

👀 [Preview Link](https://62d87c2082fb4fdc9646f6841aea4fc5-vibe-world.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>62d87c2082fb4fdc9646f6841aea4fc5</projectId>-->
<!--<branchName>vibe-world</branchName>-->