### PR TITLE
Fix NOC export to show only product ID when available

### DIFF
--- a/server/routes/export.ts
+++ b/server/routes/export.ts
@@ -1154,9 +1154,7 @@ async function generateNOCHtml(
 
   // Generate application number based on registration ID and date
   const appNumber = `GI-BODO-${new Date().getFullYear()}-${registration.id.toString().padStart(4, "0")}`;
-  const displayAppNumber = primaryProductId
-    ? `${appNumber} - Product ID: ${primaryProductId}`
-    : appNumber;
+  const displayAppNumber = primaryProductId || appNumber;
 
   // Organization details - Generic for bulk exports covering multiple associations
   const organizationName = "Bodo Traditional Producers Consortium";


### PR DESCRIPTION
## Purpose
The user reported that NOC exports were showing the full application number format "GI-BODO-2025-3299 - Product ID: 968" instead of just the product ID "968" when a product ID is available. They wanted the export to display only the product ID for cleaner output.

## Code changes
- Modified the `displayAppNumber` logic in `generateNOCHtml` function
- Simplified the conditional to use `primaryProductId` directly when available, falling back to `appNumber` when not
- Removed the concatenated format that included both application number and product ID labelTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 33`

🔗 [Edit in Builder.io](https://builder.io/app/projects/62d87c2082fb4fdc9646f6841aea4fc5/cosmos-hub)

👀 [Preview Link](https://62d87c2082fb4fdc9646f6841aea4fc5-cosmos-hub.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>62d87c2082fb4fdc9646f6841aea4fc5</projectId>-->
<!--<branchName>cosmos-hub</branchName>-->