### PR TITLE
Fix years of production calculation for Bodo Aronai

### DIFF
--- a/server/routes/registrations.ts
+++ b/server/routes/registrations.ts
@@ -2502,9 +2502,8 @@ async function generateProductStatementHtml(
 
   const giArea = "Bodoland Territorial Area Districts (BTAD)";
 
-  const registrationYear = new Date(registration.created_at).getFullYear();
+  const registrationYear = registration.created_at ? new Date(registration.created_at).getFullYear() : new Date().getFullYear();
   const currentYear = new Date().getFullYear();
-  const yearsOfExperience = Math.max(2, currentYear - registrationYear + 2);
 
   // Resolve production and turnover dynamically
   let estimatedProduction = "Not specified";
@@ -2532,6 +2531,18 @@ async function generateProductStatementHtml(
     }
 
     const detail = rows && rows[0];
+
+    // Determine years of production: prefer explicit value from production detail, then registration, else compute from registration date
+    let yearsOfExperience: number | null = null;
+    if (detail && detail.years_of_production) {
+      yearsOfExperience = parseInt(String(detail.years_of_production)) || null;
+    } else if (registration.years_of_production) {
+      yearsOfExperience = parseInt(String(registration.years_of_production)) || null;
+    } else if (registration.created_at) {
+      yearsOfExperience = Math.max(1, currentYear - registrationYear);
+    } else {
+      yearsOfExperience = 1;
+    }
 
     console.log("🔎 Statement data lookup:", {
       productId,

--- a/server/routes/registrations.ts
+++ b/server/routes/registrations.ts
@@ -2502,7 +2502,9 @@ async function generateProductStatementHtml(
 
   const giArea = "Bodoland Territorial Area Districts (BTAD)";
 
-  const registrationYear = registration.created_at ? new Date(registration.created_at).getFullYear() : new Date().getFullYear();
+  const registrationYear = registration.created_at
+    ? new Date(registration.created_at).getFullYear()
+    : new Date().getFullYear();
   const currentYear = new Date().getFullYear();
 
   // Resolve production and turnover dynamically
@@ -2537,7 +2539,8 @@ async function generateProductStatementHtml(
     if (detail && detail.years_of_production) {
       yearsOfExperience = parseInt(String(detail.years_of_production)) || null;
     } else if (registration.years_of_production) {
-      yearsOfExperience = parseInt(String(registration.years_of_production)) || null;
+      yearsOfExperience =
+        parseInt(String(registration.years_of_production)) || null;
     } else if (registration.created_at) {
       yearsOfExperience = Math.max(1, currentYear - registrationYear);
     } else {


### PR DESCRIPTION
## Purpose

The user is involved in Bodo Aronai production within the BTAD GI Area and identified an issue where the export statement showed static "2 years" instead of reflecting their actual years of production experience. They needed the system to accurately calculate and display their real production history.

## Code changes

- **Enhanced years of experience calculation**: Replaced the hardcoded minimum of 2 years with a dynamic calculation that prioritizes explicit production data
- **Added fallback logic**: Implemented a hierarchy to determine years of production:
  1. First checks production detail's `years_of_production` field
  2. Falls back to registration's `years_of_production` field  
  3. Calculates from registration date if available
  4. Defaults to 1 year as final fallback
- **Improved null safety**: Added proper null checking for `registration.created_at` before date operations
- **Removed arbitrary minimum**: Eliminated the `Math.max(2, ...)` constraint that was forcing a 2-year minimum regardless of actual experienceTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 35`

🔗 [Edit in Builder.io](https://builder.io/app/projects/62d87c2082fb4fdc9646f6841aea4fc5/pixel-landing)

👀 [Preview Link](https://62d87c2082fb4fdc9646f6841aea4fc5-pixel-landing.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>62d87c2082fb4fdc9646f6841aea4fc5</projectId>-->
<!--<branchName>pixel-landing</branchName>-->