### PR TITLE
Remove pagination when searching to show all results

### DIFF
--- a/client/pages/AdminDashboard.tsx
+++ b/client/pages/AdminDashboard.tsx
@@ -667,7 +667,10 @@ export default function AdminDashboard() {
                     type="text"
                     placeholder="Search by name, phone, Aadhar number, or Voter ID..."
                     value={searchTerm}
-                    onChange={(e) => { setSearchTerm(e.target.value); setCurrentPage(1); }}
+                    onChange={(e) => {
+                      setSearchTerm(e.target.value);
+                      setCurrentPage(1);
+                    }}
                     className="pl-10"
                   />
                 </div>

--- a/client/pages/AdminDashboard.tsx
+++ b/client/pages/AdminDashboard.tsx
@@ -157,13 +157,28 @@ export default function AdminDashboard() {
     } else {
       navigate("/");
     }
-  }, [navigate, currentPage]);
+  }, [navigate, currentPage, searchTerm]);
 
   const fetchRegistrations = async (retryCount = 0) => {
     try {
       setLoading(true);
       console.log("Fetching registrations...");
-      const data = await registrationsAPI.getAllRegistrations(currentPage, 10);
+
+      let data;
+
+      // If the user is performing a search, fetch all registrations so client-side filtering
+      // works across the entire dataset and pagination does not hide results.
+      if (searchTerm && searchTerm.trim() !== "") {
+        const desiredLimit =
+          typeof statistics?.totalRegistrations === "number" &&
+          statistics.totalRegistrations > 0
+            ? statistics.totalRegistrations
+            : 10000;
+        data = await registrationsAPI.getAllRegistrations(1, desiredLimit);
+      } else {
+        data = await registrationsAPI.getAllRegistrations(currentPage, 10);
+      }
+
       console.log("Registrations data:", data);
 
       setRegistrations(data.registrations || []);
@@ -652,7 +667,7 @@ export default function AdminDashboard() {
                     type="text"
                     placeholder="Search by name, phone, Aadhar number, or Voter ID..."
                     value={searchTerm}
-                    onChange={(e) => setSearchTerm(e.target.value)}
+                    onChange={(e) => { setSearchTerm(e.target.value); setCurrentPage(1); }}
                     className="pl-10"
                   />
                 </div>


### PR DESCRIPTION
## Purpose
User reported that search functionality was limited by pagination, preventing them from seeing all matching results across different pages. The goal was to modify the search behavior to display all matching data without pagination restrictions.

## Code changes
- Modified `fetchRegistrations` function to fetch all registrations when a search term is present, using either the total registration count or a fallback limit of 10,000
- Added `searchTerm` to the useEffect dependency array to trigger re-fetching when search changes
- Updated search input onChange handler to reset current page to 1 when searching
- Maintained existing pagination behavior for non-search scenariosTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 40`

🔗 [Edit in Builder.io](https://builder.io/app/projects/62d87c2082fb4fdc9646f6841aea4fc5/cosmos-haven)

👀 [Preview Link](https://62d87c2082fb4fdc9646f6841aea4fc5-cosmos-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>62d87c2082fb4fdc9646f6841aea4fc5</projectId>-->
<!--<branchName>cosmos-haven</branchName>-->