### PR TITLE
Add user-specific registration and application cards

### DIFF
--- a/client/pages/DashboardFixed.tsx
+++ b/client/pages/DashboardFixed.tsx
@@ -40,13 +40,19 @@ export default function DashboardFixed() {
       const userDataRaw = localStorage.getItem("user");
       if (userDataRaw) {
         try {
-          const userRegsResp: any = await registrationsAPI.getUserRegistrations();
+          const userRegsResp: any =
+            await registrationsAPI.getUserRegistrations();
           let regs: any[] = [];
           if (Array.isArray(userRegsResp)) regs = userRegsResp;
-          else if (userRegsResp && userRegsResp.registrations) regs = userRegsResp.registrations;
+          else if (userRegsResp && userRegsResp.registrations)
+            regs = userRegsResp.registrations;
           myRegistrationsCount = regs.length;
           myApplicationsCount = regs.filter((r) => {
-            const sel = r.selected_products || r.selectedProducts || r.existing_products || r.existingProducts;
+            const sel =
+              r.selected_products ||
+              r.selectedProducts ||
+              r.existing_products ||
+              r.existingProducts;
             if (!sel) return false;
             if (typeof sel === "string") {
               const trimmed = sel.trim();
@@ -191,7 +197,9 @@ export default function DashboardFixed() {
                 </svg>
               </div>
               <div className="ml-4">
-                <p className="text-sm font-medium text-gray-600">Total Applications</p>
+                <p className="text-sm font-medium text-gray-600">
+                  Total Applications
+                </p>
                 <p className="text-2xl font-bold text-gray-900">
                   {typeof stats.totalApplications === "number"
                     ? stats.totalApplications
@@ -204,14 +212,33 @@ export default function DashboardFixed() {
           <div className="bg-white rounded-lg shadow p-6">
             <div className="flex items-center">
               <div className="p-2 bg-yellow-100 rounded-lg">
-                <svg className="w-6 h-6 text-yellow-600" viewBox="0 0 24 24" fill="none" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4z" />
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 20v-1a4 4 0 014-4h4a4 4 0 014 4v1" />
+                <svg
+                  className="w-6 h-6 text-yellow-600"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4z"
+                  />
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M6 20v-1a4 4 0 014-4h4a4 4 0 014 4v1"
+                  />
                 </svg>
               </div>
               <div className="ml-4">
-                <p className="text-sm font-medium text-gray-600">My Registrations</p>
-                <p className="text-2xl font-bold text-gray-900">{stats.myRegistrations}</p>
+                <p className="text-sm font-medium text-gray-600">
+                  My Registrations
+                </p>
+                <p className="text-2xl font-bold text-gray-900">
+                  {stats.myRegistrations}
+                </p>
               </div>
             </div>
           </div>
@@ -219,13 +246,27 @@ export default function DashboardFixed() {
           <div className="bg-white rounded-lg shadow p-6">
             <div className="flex items-center">
               <div className="p-2 bg-green-100 rounded-lg">
-                <svg className="w-6 h-6 text-green-600" viewBox="0 0 24 24" fill="none" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 7h18M3 12h18M3 17h18" />
+                <svg
+                  className="w-6 h-6 text-green-600"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M3 7h18M3 12h18M3 17h18"
+                  />
                 </svg>
               </div>
               <div className="ml-4">
-                <p className="text-sm font-medium text-gray-600">My Applications</p>
-                <p className="text-2xl font-bold text-gray-900">{stats.myApplications}</p>
+                <p className="text-sm font-medium text-gray-600">
+                  My Applications
+                </p>
+                <p className="text-2xl font-bold text-gray-900">
+                  {stats.myApplications}
+                </p>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Purpose
Add personalized dashboard cards to show data collector-specific metrics. The user requested to display counts of registrations and applications created by the currently logged-in data collector, alongside the existing total counts for better user experience and personal tracking.

## Code changes
- **Enhanced dashboard stats**: Added `myRegistrations` and `myApplications` to the stats state
- **User-specific data fetching**: Implemented logic to fetch and count registrations created by the logged-in user
- **Application filtering**: Added logic to identify applications by checking for selected/existing products in registrations
- **Dashboard layout**: Updated grid layout from 4 columns to accommodate new cards
- **New dashboard cards**: 
  - "My Registrations" card showing user's registration count
  - "My Applications" card showing user's application count
- **Visual updates**: Updated card styling and icons for better distinction between total and personal metrics
- **Import optimization**: Reorganized React imports for consistencyTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 41`

🔗 [Edit in Builder.io](https://builder.io/app/projects/62d87c2082fb4fdc9646f6841aea4fc5/zen-oasis)

👀 [Preview Link](https://62d87c2082fb4fdc9646f6841aea4fc5-zen-oasis.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>62d87c2082fb4fdc9646f6841aea4fc5</projectId>-->
<!--<branchName>zen-oasis</branchName>-->