### PR TITLE
Implement additional registration with document reuse

### DIFF
--- a/client/components/DocumentUpload.tsx
+++ b/client/components/DocumentUpload.tsx
@@ -113,7 +113,7 @@ export function DocumentUpload({
       </div>
 
       {/* File Preview */}
-      { (file || previewUrl) && showPreview ? (
+      {(file || previewUrl) && showPreview ? (
         <div className="mt-3">
           <div className="w-full h-32 bg-gray-100 rounded-lg overflow-hidden border">
             {previewUrl ? (
@@ -150,7 +150,7 @@ export function DocumentUpload({
             )}
           </div>
         </div>
-      ) : (file && !showPreview) ? (
+      ) : file && !showPreview ? (
         <div className="mt-3">
           <div className="flex items-center justify-between">
             <div className="text-sm text-green-600">

--- a/client/pages/RegistrationForm.tsx
+++ b/client/pages/RegistrationForm.tsx
@@ -102,7 +102,9 @@ export default function RegistrationForm() {
   } | null>(null);
   const [isAdditionalRegistration, setIsAdditionalRegistration] =
     useState(false);
-  const [baseRegistrationId, setBaseRegistrationId] = useState<number | null>(null);
+  const [baseRegistrationId, setBaseRegistrationId] = useState<number | null>(
+    null,
+  );
   const navigate = useNavigate();
 
   const [formData, setFormData] = useState<FormData>({
@@ -245,19 +247,29 @@ export default function RegistrationForm() {
         return hasBasicInfo;
       case 2: {
         const hasAadharFrontBack =
-          !!formData.documents.aadharCardFront && !!formData.documents.aadharCardBack;
+          !!formData.documents.aadharCardFront &&
+          !!formData.documents.aadharCardBack;
         const hasAadharFromBase = !!(
-          isAdditionalRegistration && verificationResult?.userData?.documentPaths?.aadharCard
+          isAdditionalRegistration &&
+          verificationResult?.userData?.documentPaths?.aadharCard
         );
-        const hasSignature = !!formData.documents.signature || !!(
-          isAdditionalRegistration && verificationResult?.userData?.documentPaths?.signature
-        );
-        const hasPhoto = !!formData.documents.photo || !!(
-          isAdditionalRegistration && verificationResult?.userData?.documentPaths?.photo
-        );
+        const hasSignature =
+          !!formData.documents.signature ||
+          !!(
+            isAdditionalRegistration &&
+            verificationResult?.userData?.documentPaths?.signature
+          );
+        const hasPhoto =
+          !!formData.documents.photo ||
+          !!(
+            isAdditionalRegistration &&
+            verificationResult?.userData?.documentPaths?.photo
+          );
 
         return !!(
-          (hasAadharFrontBack || hasAadharFromBase) && hasSignature && hasPhoto
+          (hasAadharFrontBack || hasAadharFromBase) &&
+          hasSignature &&
+          hasPhoto
         );
       }
       case 3:
@@ -561,7 +573,8 @@ export default function RegistrationForm() {
       } as const;
 
       if (isAdditionalRegistration) {
-        if (!baseRegistrationId) throw new Error("Base registration ID missing");
+        if (!baseRegistrationId)
+          throw new Error("Base registration ID missing");
 
         const additionalData = {
           baseRegistrationId,
@@ -583,7 +596,9 @@ export default function RegistrationForm() {
             fontWeight: "bold",
           },
         });
-        navigate("/dashboard", { state: { message: "Additional registration completed!" } });
+        navigate("/dashboard", {
+          state: { message: "Additional registration completed!" },
+        });
       } else {
         const result = await registrationsAPI.create(
           registrationData,
@@ -600,7 +615,9 @@ export default function RegistrationForm() {
             fontWeight: "bold",
           },
         });
-        navigate("/dashboard", { state: { message: "Registration completed!" } });
+        navigate("/dashboard", {
+          state: { message: "Registration completed!" },
+        });
       }
     } catch (err: any) {
       const errorMessage = err.message || "Something went wrong";
@@ -668,13 +685,16 @@ export default function RegistrationForm() {
       case 2: {
         const missingDocs = [] as string[];
         const aadharAvailableFromBase = !!(
-          isAdditionalRegistration && verificationResult?.userData?.documentPaths?.aadharCard
+          isAdditionalRegistration &&
+          verificationResult?.userData?.documentPaths?.aadharCard
         );
         const signatureAvailableFromBase = !!(
-          isAdditionalRegistration && verificationResult?.userData?.documentPaths?.signature
+          isAdditionalRegistration &&
+          verificationResult?.userData?.documentPaths?.signature
         );
         const photoAvailableFromBase = !!(
-          isAdditionalRegistration && verificationResult?.userData?.documentPaths?.photo
+          isAdditionalRegistration &&
+          verificationResult?.userData?.documentPaths?.photo
         );
 
         if (!formData.documents.aadharCardFront && !aadharAvailableFromBase)
@@ -846,7 +866,8 @@ export default function RegistrationForm() {
                               // Save base registration id for createAdditional
                               setBaseRegistrationId(
                                 verificationResult.registrationId ||
-                                  verificationResult.existingRegistrations?.[0]?.id ||
+                                  verificationResult.existingRegistrations?.[0]
+                                    ?.id ||
                                   null,
                               );
 
@@ -1077,31 +1098,44 @@ export default function RegistrationForm() {
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         <div className="space-y-6">
           {(() => {
-            const aadharPreview = verificationResult?.userData?.documentPaths?.aadharCard || null;
-            const panPreview = verificationResult?.userData?.documentPaths?.panCard || null;
-            const proofPreview = verificationResult?.userData?.documentPaths?.proofOfProduction || null;
-            const signaturePreview = verificationResult?.userData?.documentPaths?.signature || null;
+            const aadharPreview =
+              verificationResult?.userData?.documentPaths?.aadharCard || null;
+            const panPreview =
+              verificationResult?.userData?.documentPaths?.panCard || null;
+            const proofPreview =
+              verificationResult?.userData?.documentPaths?.proofOfProduction ||
+              null;
+            const signaturePreview =
+              verificationResult?.userData?.documentPaths?.signature || null;
 
             return (
               <>
                 <DocumentUpload
                   label="Aadhar Card (Front)"
                   file={formData.documents.aadharCardFront}
-                  onFileChange={(file) => handleFileUpload("aadharCardFront", file)}
+                  onFileChange={(file) =>
+                    handleFileUpload("aadharCardFront", file)
+                  }
                   onFileRemove={() => handleFileUpload("aadharCardFront", null)}
                   required={true}
                   disabled={isAdditionalRegistration && !!aadharPreview}
-                  previewUrl={isAdditionalRegistration ? aadharPreview : undefined}
+                  previewUrl={
+                    isAdditionalRegistration ? aadharPreview : undefined
+                  }
                 />
 
                 <DocumentUpload
                   label="Aadhar Card (Back)"
                   file={formData.documents.aadharCardBack}
-                  onFileChange={(file) => handleFileUpload("aadharCardBack", file)}
+                  onFileChange={(file) =>
+                    handleFileUpload("aadharCardBack", file)
+                  }
                   onFileRemove={() => handleFileUpload("aadharCardBack", null)}
                   required={true}
                   disabled={isAdditionalRegistration && !!aadharPreview}
-                  previewUrl={isAdditionalRegistration ? aadharPreview : undefined}
+                  previewUrl={
+                    isAdditionalRegistration ? aadharPreview : undefined
+                  }
                 />
 
                 <DocumentUpload
@@ -1117,11 +1151,17 @@ export default function RegistrationForm() {
                 <DocumentUpload
                   label="Proof of Production"
                   file={formData.documents.proofOfProduction}
-                  onFileChange={(file) => handleFileUpload("proofOfProduction", file)}
-                  onFileRemove={() => handleFileUpload("proofOfProduction", null)}
+                  onFileChange={(file) =>
+                    handleFileUpload("proofOfProduction", file)
+                  }
+                  onFileRemove={() =>
+                    handleFileUpload("proofOfProduction", null)
+                  }
                   required={false}
                   disabled={isAdditionalRegistration && !!proofPreview}
-                  previewUrl={isAdditionalRegistration ? proofPreview : undefined}
+                  previewUrl={
+                    isAdditionalRegistration ? proofPreview : undefined
+                  }
                 />
 
                 <DocumentUpload
@@ -1131,7 +1171,9 @@ export default function RegistrationForm() {
                   onFileRemove={() => handleFileUpload("signature", null)}
                   required={true}
                   disabled={isAdditionalRegistration && !!signaturePreview}
-                  previewUrl={isAdditionalRegistration ? signaturePreview : undefined}
+                  previewUrl={
+                    isAdditionalRegistration ? signaturePreview : undefined
+                  }
                 />
               </>
             );
@@ -1144,7 +1186,8 @@ export default function RegistrationForm() {
           </h3>
           <div className="w-full max-w-sm">
             {(() => {
-              const photoPreview = verificationResult?.userData?.documentPaths?.photo || null;
+              const photoPreview =
+                verificationResult?.userData?.documentPaths?.photo || null;
               return (
                 <DocumentUpload
                   label="Profile Photo"
@@ -1154,7 +1197,9 @@ export default function RegistrationForm() {
                   required={true}
                   showPreview={true}
                   disabled={isAdditionalRegistration && !!photoPreview}
-                  previewUrl={isAdditionalRegistration ? photoPreview : undefined}
+                  previewUrl={
+                    isAdditionalRegistration ? photoPreview : undefined
+                  }
                 />
               );
             })()}
@@ -1182,7 +1227,8 @@ export default function RegistrationForm() {
         <div className="mt-4 border border-gray-200 rounded-lg p-4 space-y-3 max-h-64 overflow-y-auto">
           {(() => {
             const categoriesToShow =
-              isAdditionalRegistration && verificationResult?.availableCategories
+              isAdditionalRegistration &&
+              verificationResult?.availableCategories
                 ? verificationResult.availableCategories
                 : categories;
 

--- a/server/routes/registrations.ts
+++ b/server/routes/registrations.ts
@@ -1258,11 +1258,23 @@ export async function verifyRegistration(req: Request, res: Response) {
         voterId: registration.voter_id || undefined,
         panNumber: registration.pan_number || undefined,
         documentPaths: {
-          aadharCard: registration.aadhar_card_path ? simpleFileStorage.getFileUrl(registration.aadhar_card_path) : undefined,
-          panCard: registration.pan_card_path ? simpleFileStorage.getFileUrl(registration.pan_card_path) : undefined,
-          proofOfProduction: registration.proof_of_production_path ? simpleFileStorage.getFileUrl(registration.proof_of_production_path) : undefined,
-          signature: registration.signature_path ? simpleFileStorage.getFileUrl(registration.signature_path) : undefined,
-          photo: registration.photo_path ? simpleFileStorage.getFileUrl(registration.photo_path) : undefined,
+          aadharCard: registration.aadhar_card_path
+            ? simpleFileStorage.getFileUrl(registration.aadhar_card_path)
+            : undefined,
+          panCard: registration.pan_card_path
+            ? simpleFileStorage.getFileUrl(registration.pan_card_path)
+            : undefined,
+          proofOfProduction: registration.proof_of_production_path
+            ? simpleFileStorage.getFileUrl(
+                registration.proof_of_production_path,
+              )
+            : undefined,
+          signature: registration.signature_path
+            ? simpleFileStorage.getFileUrl(registration.signature_path)
+            : undefined,
+          photo: registration.photo_path
+            ? simpleFileStorage.getFileUrl(registration.photo_path)
+            : undefined,
         },
       };
 


### PR DESCRIPTION
## Purpose

The user requested implementation of an "additional registration" feature that allows users to create new registrations while reusing documents from their existing base registration. The goal is to:

- Enable users to register for additional product categories without re-uploading documents
- Show existing documents as read-only previews in step 2
- Filter out already registered categories/products in steps 3-4
- Call a new `createAdditional` API endpoint that reuses documents from the base registration

## Code changes

### Frontend Changes
- **DocumentUpload component**: Added `previewUrl` prop to display existing document previews without requiring file uploads
- **RegistrationForm**: 
  - Added state management for additional registration mode and base registration ID
  - Modified step 2 validation to accept documents from base registration
  - Updated document upload sections to show read-only previews when documents exist from base registration
  - Filtered categories and products in steps 3-4 to exclude already registered items
  - Added separate submission flow for additional registrations using `createAdditional` API

### Backend Changes
- **Registration verification**: Enhanced to return full file URLs for document paths instead of just file paths, enabling proper preview display in the frontend

The implementation ensures users can seamlessly create additional registrations while maintaining a smooth UX with document reuse and proper filtering of existing registrations.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 42`

🔗 [Edit in Builder.io](https://builder.io/app/projects/2eb5c48bd3004e1ab2fb73f96a87c867/quantum-verse)

👀 [Preview Link](https://2eb5c48bd3004e1ab2fb73f96a87c867-quantum-verse.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>2eb5c48bd3004e1ab2fb73f96a87c867</projectId>-->
<!--<branchName>quantum-verse</branchName>-->